### PR TITLE
feat: itinerary sharing — share links and live read-only follower views (issue #8)

### DIFF
--- a/app/(app)/dashboard/page.tsx
+++ b/app/(app)/dashboard/page.tsx
@@ -14,18 +14,30 @@ export default async function DashboardPage() {
   const session = await getServerSession(authOptions);
   if (!session) redirect("/login");
 
-  const trips = await prisma.trip.findMany({
-    where: { user_id: session.user.id },
-    select: {
-      id: true,
-      name: true,
-      destination: true,
-      start_date: true,
-      end_date: true,
-      created_at: true,
-    },
-    orderBy: { created_at: "desc" },
-  });
+  const [trips, followedRaw] = await Promise.all([
+    prisma.trip.findMany({
+      where: { user_id: session.user.id },
+      select: {
+        id: true,
+        name: true,
+        destination: true,
+        start_date: true,
+        end_date: true,
+        created_at: true,
+      },
+      orderBy: { created_at: "desc" },
+    }),
+    prisma.tripFollow.findMany({
+      where: { follower_id: session.user.id },
+      include: { trip: { include: { user: { select: { name: true } } } } },
+      orderBy: { created_at: "desc" },
+    }),
+  ]);
+
+  const followedTrips = followedRaw.map((f) => ({
+    ...f.trip,
+    sharedBy: f.trip.user.name || "a TripForge user",
+  }));
 
   return (
     <div className="mx-auto max-w-5xl px-4 py-10">
@@ -34,9 +46,9 @@ export default async function DashboardPage() {
         <div>
           <h1 className="font-serif text-3xl font-semibold text-ink">My Trips</h1>
           <p className="mt-1 text-sm text-muted">
-            {trips.length === 0
+            {trips.length === 0 && followedTrips.length === 0
               ? "Upload your first itinerary to get started."
-              : `${trips.length} trip${trips.length !== 1 ? "s" : ""}`}
+              : `${trips.length} trip${trips.length !== 1 ? "s" : ""}${followedTrips.length > 0 ? ` · ${followedTrips.length} saved` : ""}`}
           </p>
         </div>
         <Link
@@ -48,8 +60,8 @@ export default async function DashboardPage() {
         </Link>
       </div>
 
-      {/* Empty state */}
-      {trips.length === 0 ? (
+      {/* Content */}
+      {trips.length === 0 && followedTrips.length === 0 ? (
         <div className="mt-16 flex flex-col items-center gap-4 text-center">
           <div className="flex h-16 w-16 items-center justify-center rounded-full bg-parchment">
             <Compass className="h-8 w-8 text-rust" aria-hidden="true" />
@@ -69,11 +81,25 @@ export default async function DashboardPage() {
           </Link>
         </div>
       ) : (
-        <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
-          {trips.map((trip) => (
-            <TripCard key={trip.id} {...trip} />
-          ))}
-        </div>
+        <>
+          {trips.length > 0 && (
+            <div className="mt-8 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+              {trips.map((trip) => (
+                <TripCard key={trip.id} {...trip} />
+              ))}
+            </div>
+          )}
+          {followedTrips.length > 0 && (
+            <div className="mt-10">
+              <h2 className="font-serif text-2xl font-semibold text-ink">Saved Trips</h2>
+              <div className="mt-4 grid gap-4 sm:grid-cols-2 lg:grid-cols-3">
+                {followedTrips.map((trip) => (
+                  <TripCard key={trip.id} {...trip} sharedBy={trip.sharedBy} />
+                ))}
+              </div>
+            </div>
+          )}
+        </>
       )}
     </div>
   );

--- a/app/(app)/trips/[id]/page.tsx
+++ b/app/(app)/trips/[id]/page.tsx
@@ -24,6 +24,7 @@ export default async function TripPage({ params }: TripPageProps) {
       destination: true,
       start_date: true,
       end_date: true,
+      user: { select: { name: true } },
       days: {
         orderBy: { day_number: "asc" },
         select: {
@@ -52,7 +53,26 @@ export default async function TripPage({ params }: TripPageProps) {
     },
   });
 
-  if (!trip || trip.user_id !== session.user.id) notFound();
+  if (!trip) notFound();
+
+  const isOwner = trip.user_id === session.user.id;
+
+  const follow = !isOwner
+    ? await prisma.tripFollow.findUnique({
+        where: {
+          follower_id_trip_id: {
+            follower_id: session.user.id,
+            trip_id: trip.id,
+          },
+        },
+      })
+    : null;
+
+  if (!isOwner && !follow) notFound();
+
+  const ownerName: string | undefined = isOwner
+    ? undefined
+    : (trip.user.name || "a TripForge user");
 
   // Run geocoding backfill and checklist fetch in parallel.
   const [, checklistRaw] = await Promise.all([
@@ -142,5 +162,12 @@ export default async function TripPage({ params }: TripPageProps) {
     })),
   };
 
-  return <TripCompanionClient trip={tripDetail} checklist={checklist} />;
+  return (
+    <TripCompanionClient
+      trip={tripDetail}
+      checklist={checklist}
+      readOnly={!isOwner}
+      ownerName={ownerName}
+    />
+  );
 }

--- a/app/api/share/[token]/follow/route.ts
+++ b/app/api/share/[token]/follow/route.ts
@@ -1,0 +1,34 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { NextResponse } from "next/server";
+
+/**
+ * POST /api/share/[token]/follow
+ *
+ * Creates a TripFollow record for the logged-in user (upsert — idempotent).
+ * Returns { tripId } so the client can redirect to /trips/[tripId].
+ */
+export async function POST(_req: Request, { params }: { params: { token: string } }) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Authentication required.", code: "UNAUTHORIZED" }, { status: 401 });
+  }
+
+  const trip = await prisma.trip.findFirst({
+    where: { share_token: params.token },
+    select: { id: true, user_id: true },
+  });
+
+  if (!trip) {
+    return NextResponse.json({ error: "Share link not found.", code: "NOT_FOUND" }, { status: 404 });
+  }
+
+  await prisma.tripFollow.upsert({
+    where: { follower_id_trip_id: { follower_id: session.user.id, trip_id: trip.id } },
+    create: { follower_id: session.user.id, trip_id: trip.id },
+    update: {},
+  });
+
+  return NextResponse.json({ tripId: trip.id });
+}

--- a/app/api/share/[token]/route.ts
+++ b/app/api/share/[token]/route.ts
@@ -1,0 +1,35 @@
+import { prisma } from "@/lib/prisma";
+import { NextResponse } from "next/server";
+
+/**
+ * GET /api/share/[token]
+ *
+ * Public — no auth required. Returns trip preview metadata by share token.
+ * Used by external consumers. The invite page server component queries Prisma directly.
+ */
+export async function GET(_req: Request, { params }: { params: { token: string } }) {
+  const trip = await prisma.trip.findFirst({
+    where: { share_token: params.token },
+    select: {
+      id: true,
+      name: true,
+      destination: true,
+      start_date: true,
+      end_date: true,
+      user: { select: { name: true } },
+    },
+  });
+
+  if (!trip) {
+    return NextResponse.json({ error: "Share link not found.", code: "NOT_FOUND" }, { status: 404 });
+  }
+
+  return NextResponse.json({
+    tripId: trip.id,
+    name: trip.name,
+    destination: trip.destination,
+    start_date: trip.start_date?.toISOString().slice(0, 10) ?? null,
+    end_date: trip.end_date?.toISOString().slice(0, 10) ?? null,
+    ownerName: trip.user.name || "a TripForge user",
+  });
+}

--- a/app/api/trips/[id]/chat/route.ts
+++ b/app/api/trips/[id]/chat/route.ts
@@ -107,11 +107,23 @@ export async function POST(
     );
   }
 
-  if (trip.user_id !== session.user.id) {
-    return new Response(
-      JSON.stringify({ error: "You do not have access to this trip.", code: "FORBIDDEN" }),
-      { status: 403, headers: { "Content-Type": "application/json" } }
-    );
+  const isOwner = trip.user_id === session.user.id;
+  if (!isOwner) {
+    const follow = await prisma.tripFollow.findUnique({
+      where: {
+        follower_id_trip_id: {
+          follower_id: session.user.id,
+          trip_id: trip.id,
+        },
+      },
+      select: { id: true },
+    });
+    if (!follow) {
+      return new Response(
+        JSON.stringify({ error: "You do not have access to this trip.", code: "FORBIDDEN" }),
+        { status: 403, headers: { "Content-Type": "application/json" } }
+      );
+    }
   }
 
   // Serialize dates for the system prompt builder

--- a/app/api/trips/[id]/follow/route.ts
+++ b/app/api/trips/[id]/follow/route.ts
@@ -1,0 +1,35 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { NextResponse } from "next/server";
+
+/**
+ * DELETE /api/trips/[id]/follow
+ *
+ * Removes the TripFollow record for the current user (unsave).
+ * No-op if no follow record exists. 404 if the trip itself doesn't exist.
+ */
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return NextResponse.json({ error: "Authentication required.", code: "UNAUTHORIZED" }, { status: 401 });
+  }
+
+  const trip = await prisma.trip.findUnique({ where: { id: params.id }, select: { id: true } });
+  if (!trip) {
+    return NextResponse.json({ error: "Trip not found.", code: "NOT_FOUND" }, { status: 404 });
+  }
+
+  const follow = await prisma.tripFollow.findUnique({
+    where: { follower_id_trip_id: { follower_id: session.user.id, trip_id: params.id } },
+    select: { id: true },
+  });
+
+  if (follow) {
+    await prisma.tripFollow.delete({
+      where: { follower_id_trip_id: { follower_id: session.user.id, trip_id: params.id } },
+    });
+  }
+
+  return new Response(null, { status: 204 });
+}

--- a/app/api/trips/[id]/route.ts
+++ b/app/api/trips/[id]/route.ts
@@ -72,11 +72,23 @@ export async function GET(
       );
     }
 
-    if (trip.user_id !== session.user.id) {
-      return NextResponse.json(
-        { error: "You do not have access to this trip.", code: "FORBIDDEN" },
-        { status: 403 }
-      );
+    const isOwner = trip.user_id === session.user.id;
+    if (!isOwner) {
+      const follow = await prisma.tripFollow.findUnique({
+        where: {
+          follower_id_trip_id: {
+            follower_id: session.user.id,
+            trip_id: trip.id,
+          },
+        },
+        select: { id: true },
+      });
+      if (!follow) {
+        return NextResponse.json(
+          { error: "You do not have access to this trip.", code: "FORBIDDEN" },
+          { status: 403 }
+        );
+      }
     }
 
     // Strip user_id from the response

--- a/app/api/trips/[id]/share/route.ts
+++ b/app/api/trips/[id]/share/route.ts
@@ -1,0 +1,49 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { prisma } from "@/lib/prisma";
+import { NextResponse } from "next/server";
+import crypto from "node:crypto";
+
+async function getOwnerTrip(tripId: string) {
+  const session = await getServerSession(authOptions);
+  if (!session?.user?.id) {
+    return { error: NextResponse.json({ error: "Authentication required.", code: "UNAUTHORIZED" }, { status: 401 }) };
+  }
+  const trip = await prisma.trip.findUnique({
+    where: { id: tripId },
+    select: { id: true, user_id: true, share_token: true },
+  });
+  if (!trip) {
+    return { error: NextResponse.json({ error: "Trip not found.", code: "NOT_FOUND" }, { status: 404 }) };
+  }
+  if (trip.user_id !== session.user.id) {
+    return { error: NextResponse.json({ error: "You do not have access to this trip.", code: "FORBIDDEN" }, { status: 403 }) };
+  }
+  return { trip };
+}
+
+/** POST /api/trips/[id]/share — generate share token (idempotent; Node.js runtime only) */
+export async function POST(_req: Request, { params }: { params: { id: string } }) {
+  const auth = await getOwnerTrip(params.id);
+  if ("error" in auth) return auth.error;
+
+  const { trip } = auth;
+  const baseUrl = process.env.NEXTAUTH_URL ?? "";
+
+  if (trip.share_token) {
+    return NextResponse.json({ url: `${baseUrl}/share/${trip.share_token}` });
+  }
+
+  const token = crypto.randomBytes(32).toString("hex");
+  await prisma.trip.update({ where: { id: trip.id }, data: { share_token: token } });
+  return NextResponse.json({ url: `${baseUrl}/share/${token}` });
+}
+
+/** DELETE /api/trips/[id]/share — revoke share token (keeps TripFollow records) */
+export async function DELETE(_req: Request, { params }: { params: { id: string } }) {
+  const auth = await getOwnerTrip(params.id);
+  if ("error" in auth) return auth.error;
+
+  await prisma.trip.update({ where: { id: auth.trip.id }, data: { share_token: null } });
+  return NextResponse.json({ success: true });
+}

--- a/app/share/[token]/page.tsx
+++ b/app/share/[token]/page.tsx
@@ -1,0 +1,99 @@
+import { getServerSession } from "next-auth";
+import { authOptions } from "@/lib/auth";
+import { redirect } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+import Link from "next/link";
+import { MapPin, Calendar, AlertCircle } from "lucide-react";
+import { ShareSaveButton } from "@/components/ShareSaveButton";
+
+interface SharePageProps {
+  params: { token: string };
+}
+
+export default async function SharePage({ params }: SharePageProps) {
+  const session = await getServerSession(authOptions);
+  if (!session) {
+    redirect(`/login?callbackUrl=/share/${params.token}`);
+  }
+
+  const trip = await prisma.trip.findFirst({
+    where: { share_token: params.token },
+    select: {
+      id: true,
+      user_id: true,
+      name: true,
+      destination: true,
+      start_date: true,
+      end_date: true,
+      user: { select: { name: true } },
+    },
+  });
+
+  if (!trip) {
+    return (
+      <div className="flex min-h-screen items-center justify-center px-4">
+        <div className="flex flex-col items-center gap-3 text-center">
+          <AlertCircle className="h-10 w-10 text-muted" />
+          <h1 className="font-serif text-2xl font-semibold text-ink">Link no longer active</h1>
+          <p className="text-sm text-muted">This invite link has expired or been removed.</p>
+          <Link href="/dashboard" className="mt-2 text-sm font-medium text-rust hover:underline">
+            Go to your dashboard
+          </Link>
+        </div>
+      </div>
+    );
+  }
+
+  const isOwner = session.user.id === trip.user_id;
+  const follow = !isOwner
+    ? await prisma.tripFollow.findUnique({
+        where: { follower_id_trip_id: { follower_id: session.user.id, trip_id: trip.id } },
+        select: { id: true },
+      })
+    : null;
+
+  const initialState: "owner" | "follower" | "stranger" = isOwner
+    ? "owner"
+    : follow
+    ? "follower"
+    : "stranger";
+
+  const ownerName = trip.user.name || "a TripForge user";
+
+  let dateRange: string | null = null;
+  if (trip.start_date && trip.end_date) {
+    const fmt = (d: Date) =>
+      d.toLocaleDateString("en-US", { month: "short", day: "numeric", year: "numeric" });
+    dateRange = `${fmt(trip.start_date)} – ${fmt(trip.end_date)}`;
+  }
+
+  return (
+    <div className="flex min-h-screen items-center justify-center px-4 py-12">
+      <div className="w-full max-w-sm rounded-2xl bg-parchment p-8 shadow-card">
+        <p className="text-xs font-medium uppercase tracking-wide text-muted">
+          Shared by {ownerName}
+        </p>
+        <h1 className="mt-2 font-serif text-2xl font-semibold text-ink">{trip.name}</h1>
+        <div className="mt-4 space-y-2">
+          <div className="flex items-center gap-2 text-sm text-muted">
+            <MapPin className="h-4 w-4 shrink-0" aria-hidden="true" />
+            <span>{trip.destination}</span>
+          </div>
+          {dateRange && (
+            <div className="flex items-center gap-2 text-sm text-muted">
+              <Calendar className="h-4 w-4 shrink-0" aria-hidden="true" />
+              <span>{dateRange}</span>
+            </div>
+          )}
+        </div>
+        <div className="mt-6">
+          <ShareSaveButton
+            token={params.token}
+            tripId={trip.id}
+            initialState={initialState}
+          />
+        </div>
+      </div>
+    </div>
+  );
+}

--- a/app/share/layout.tsx
+++ b/app/share/layout.tsx
@@ -1,0 +1,3 @@
+export default function ShareLayout({ children }: { children: React.ReactNode }) {
+  return <div className="min-h-screen bg-cream">{children}</div>;
+}

--- a/components/ChecklistTab.tsx
+++ b/components/ChecklistTab.tsx
@@ -7,6 +7,7 @@ import type { ChecklistItem } from "@/types/trip";
 interface ChecklistTabProps {
   tripId: string;
   initialItems: ChecklistItem[];
+  readOnly?: boolean;
 }
 
 const CATEGORIES = [
@@ -44,7 +45,7 @@ function groupByCategory(items: ChecklistItem[]): Map<string, ChecklistItem[]> {
  * - Items can be deleted with the trash icon (X).
  * - Progress indicator shows "X of Y packed".
  */
-export function ChecklistTab({ tripId, initialItems }: ChecklistTabProps) {
+export function ChecklistTab({ tripId, initialItems, readOnly = false }: ChecklistTabProps) {
   const [items, setItems] = useState<ChecklistItem[]>(initialItems);
   const [newLabel, setNewLabel] = useState("");
   const [newCategory, setNewCategory] = useState(CATEGORIES[0]);
@@ -203,82 +204,84 @@ export function ChecklistTab({ tripId, initialItems }: ChecklistTabProps) {
         </div>
       )}
 
-      {/* Add custom item form */}
-      <form
-        onSubmit={handleAdd}
-        className="pb-2 border-b border-parchment-dark space-y-2"
-        aria-label="Add custom item"
-      >
-        <p className="text-xs font-semibold uppercase tracking-wider text-muted">Add item</p>
-        <div className="flex gap-2">
-          <div ref={categoryRef} className="relative w-28 shrink-0">
-            <button
-              type="button"
-              aria-label="Category"
-              aria-expanded={categoryOpen}
-              aria-haspopup="listbox"
-              onClick={() => setCategoryOpen((o) => !o)}
-              className="w-full flex items-center gap-1 rounded-lg border border-parchment-dark bg-white pl-3 pr-2 py-2 text-sm text-ink hover:border-parchment-deep focus:outline-none focus:ring-2 focus:ring-rust/40 transition-colors"
-            >
-              <span className="flex-1 truncate text-left">{newCategory}</span>
-              <ChevronDown
-                className={[
-                  "h-3.5 w-3.5 text-muted transition-transform duration-150",
-                  categoryOpen ? "rotate-180" : "",
-                ].join(" ")}
-                aria-hidden="true"
-              />
-            </button>
-
-            {categoryOpen && (
-              <ul
-                role="listbox"
+      {/* Add custom item form — hidden in readOnly mode */}
+      {!readOnly && (
+        <form
+          onSubmit={handleAdd}
+          className="pb-2 border-b border-parchment-dark space-y-2"
+          aria-label="Add custom item"
+        >
+          <p className="text-xs font-semibold uppercase tracking-wider text-muted">Add item</p>
+          <div className="flex gap-2">
+            <div ref={categoryRef} className="relative w-28 shrink-0">
+              <button
+                type="button"
                 aria-label="Category"
-                className="absolute left-0 top-full mt-1 z-30 min-w-full rounded-lg border border-parchment-dark bg-white shadow-md py-1 overflow-hidden"
+                aria-expanded={categoryOpen}
+                aria-haspopup="listbox"
+                onClick={() => setCategoryOpen((o) => !o)}
+                className="w-full flex items-center gap-1 rounded-lg border border-parchment-dark bg-white pl-3 pr-2 py-2 text-sm text-ink hover:border-parchment-deep focus:outline-none focus:ring-2 focus:ring-rust/40 transition-colors"
               >
-                {CATEGORIES.map((cat) => (
-                  <li
-                    key={cat}
-                    role="option"
-                    aria-selected={cat === newCategory}
-                    onMouseDown={(e) => {
-                      e.preventDefault(); // prevent blur on label input
-                      setNewCategory(cat);
-                      setCategoryOpen(false);
-                    }}
-                    className={[
-                      "px-3 py-1.5 text-sm cursor-pointer select-none",
-                      cat === newCategory
-                        ? "bg-parchment text-rust font-medium"
-                        : "text-ink hover:bg-parchment",
-                    ].join(" ")}
-                  >
-                    {cat}
-                  </li>
-                ))}
-              </ul>
-            )}
+                <span className="flex-1 truncate text-left">{newCategory}</span>
+                <ChevronDown
+                  className={[
+                    "h-3.5 w-3.5 text-muted transition-transform duration-150",
+                    categoryOpen ? "rotate-180" : "",
+                  ].join(" ")}
+                  aria-hidden="true"
+                />
+              </button>
+
+              {categoryOpen && (
+                <ul
+                  role="listbox"
+                  aria-label="Category"
+                  className="absolute left-0 top-full mt-1 z-30 min-w-full rounded-lg border border-parchment-dark bg-white shadow-md py-1 overflow-hidden"
+                >
+                  {CATEGORIES.map((cat) => (
+                    <li
+                      key={cat}
+                      role="option"
+                      aria-selected={cat === newCategory}
+                      onMouseDown={(e) => {
+                        e.preventDefault(); // prevent blur on label input
+                        setNewCategory(cat);
+                        setCategoryOpen(false);
+                      }}
+                      className={[
+                        "px-3 py-1.5 text-sm cursor-pointer select-none",
+                        cat === newCategory
+                          ? "bg-parchment text-rust font-medium"
+                          : "text-ink hover:bg-parchment",
+                      ].join(" ")}
+                    >
+                      {cat}
+                    </li>
+                  ))}
+                </ul>
+              )}
+            </div>
+            <input
+              ref={labelInputRef}
+              type="text"
+              value={newLabel}
+              onChange={(e) => setNewLabel(e.target.value)}
+              placeholder="Item name…"
+              aria-label="New item name"
+              className="flex-1 min-w-0 rounded-lg border border-parchment-dark bg-white px-3 py-2 text-sm text-ink placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-rust/40"
+            />
+            <button
+              type="submit"
+              disabled={!newLabel.trim() || isAdding}
+              aria-label="Add item"
+              className="shrink-0 flex items-center gap-1.5 rounded-lg bg-rust px-3 py-2 text-sm font-medium text-white hover:bg-rust-dark disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
+            >
+              <Plus className="h-4 w-4" aria-hidden="true" />
+              Add
+            </button>
           </div>
-          <input
-            ref={labelInputRef}
-            type="text"
-            value={newLabel}
-            onChange={(e) => setNewLabel(e.target.value)}
-            placeholder="Item name…"
-            aria-label="New item name"
-            className="flex-1 min-w-0 rounded-lg border border-parchment-dark bg-white px-3 py-2 text-sm text-ink placeholder:text-muted focus:outline-none focus:ring-2 focus:ring-rust/40"
-          />
-          <button
-            type="submit"
-            disabled={!newLabel.trim() || isAdding}
-            aria-label="Add item"
-            className="shrink-0 flex items-center gap-1.5 rounded-lg bg-rust px-3 py-2 text-sm font-medium text-white hover:bg-rust-dark disabled:opacity-40 disabled:cursor-not-allowed transition-colors"
-          >
-            <Plus className="h-4 w-4" aria-hidden="true" />
-            Add
-          </button>
-        </div>
-      </form>
+        </form>
+      )}
 
       {/* Empty state */}
       {totalCount === 0 && (
@@ -306,6 +309,7 @@ export function ChecklistTab({ tripId, initialItems }: ChecklistTabProps) {
                     id={`item-${item.id}`}
                     checked={item.checked}
                     onChange={(e) => handleToggle(item.id, e.target.checked)}
+                    disabled={readOnly}
                     className="h-4 w-4 rounded border-parchment-deep text-rust accent-rust shrink-0"
                     aria-label={item.label}
                   />
@@ -329,13 +333,15 @@ export function ChecklistTab({ tripId, initialItems }: ChecklistTabProps) {
                       <Info className="h-3.5 w-3.5" aria-hidden="true" />
                     </button>
                   )}
-                  <button
-                    onClick={() => handleDelete(item.id)}
-                    aria-label={`Delete ${item.label}`}
-                    className="shrink-0 text-parchment-deep hover:text-rust transition-colors p-0.5"
-                  >
-                    <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
-                  </button>
+                  {!readOnly && (
+                    <button
+                      onClick={() => handleDelete(item.id)}
+                      aria-label={`Delete ${item.label}`}
+                      className="shrink-0 text-parchment-deep hover:text-rust transition-colors p-0.5"
+                    >
+                      <Trash2 className="h-3.5 w-3.5" aria-hidden="true" />
+                    </button>
+                  )}
                 </div>
                 {tooltipId === item.id && item.reason && (
                   <div

--- a/components/ShareSaveButton.tsx
+++ b/components/ShareSaveButton.tsx
@@ -1,0 +1,70 @@
+"use client";
+
+import { useState } from "react";
+import { useRouter } from "next/navigation";
+import Link from "next/link";
+
+interface ShareSaveButtonProps {
+  token: string;
+  tripId: string;
+  initialState: "owner" | "follower" | "stranger";
+}
+
+export function ShareSaveButton({ token, tripId, initialState }: ShareSaveButtonProps) {
+  const router = useRouter();
+  const [state, setState] = useState(initialState);
+  const [saving, setSaving] = useState(false);
+
+  async function handleSave() {
+    setSaving(true);
+    const res = await fetch(`/api/share/${token}/follow`, { method: "POST" });
+    if (res.ok) {
+      router.push(`/trips/${tripId}`);
+    } else {
+      setSaving(false);
+    }
+  }
+
+  if (state === "owner") {
+    return (
+      <div className="space-y-2">
+        <p className="text-sm text-muted text-center">You own this trip.</p>
+        <Link
+          href={`/trips/${tripId}`}
+          className="block w-full rounded-xl bg-rust py-2.5 text-center text-sm font-semibold text-cream hover:bg-rust-dark transition-colors"
+        >
+          Open trip
+        </Link>
+      </div>
+    );
+  }
+
+  if (state === "follower") {
+    return (
+      <div className="space-y-2">
+        <button
+          disabled
+          className="w-full rounded-xl bg-parchment-dark py-2.5 text-sm font-semibold text-muted cursor-not-allowed"
+        >
+          Already saved
+        </button>
+        <Link
+          href={`/trips/${tripId}`}
+          className="block text-center text-sm font-medium text-rust hover:underline"
+        >
+          Open trip
+        </Link>
+      </div>
+    );
+  }
+
+  return (
+    <button
+      onClick={handleSave}
+      disabled={saving}
+      className="w-full rounded-xl bg-rust py-2.5 text-sm font-semibold text-cream hover:bg-rust-dark transition-colors disabled:opacity-60"
+    >
+      {saving ? "Saving…" : "Save to my trips"}
+    </button>
+  );
+}

--- a/components/TripCard.tsx
+++ b/components/TripCard.tsx
@@ -7,6 +7,7 @@ interface TripCardProps {
   destination: string;
   start_date: Date | string | null;
   end_date: Date | string | null;
+  sharedBy?: string;
 }
 
 /** Formats a date to "Mon D, YYYY". Returns null for null input. */
@@ -20,7 +21,7 @@ function formatDate(date: Date | string | null): string | null {
 }
 
 /** Trip card shown in the dashboard grid. Links to the trip companion page. */
-export function TripCard({ id, name, destination, start_date, end_date }: TripCardProps) {
+export function TripCard({ id, name, destination, start_date, end_date, sharedBy }: TripCardProps) {
   const startFormatted = formatDate(start_date);
   const endFormatted = formatDate(end_date);
 
@@ -48,6 +49,11 @@ export function TripCard({ id, name, destination, start_date, end_date }: TripCa
           <div className="flex items-center gap-2 text-sm text-muted">
             <Calendar className="h-4 w-4 shrink-0" aria-hidden="true" />
             <span>{dateRange}</span>
+          </div>
+        )}
+        {sharedBy && (
+          <div className="flex items-center gap-2 text-sm text-muted">
+            <span>Shared by {sharedBy}</span>
           </div>
         )}
       </div>

--- a/components/TripCompanionClient.tsx
+++ b/components/TripCompanionClient.tsx
@@ -1,6 +1,7 @@
 "use client";
 
 import { useRef, useState } from "react";
+import { useRouter } from "next/navigation";
 import Link from "next/link";
 import {
   ArrowLeft,
@@ -9,6 +10,8 @@ import {
   Map,
   MessageCircle,
   CheckSquare,
+  Share2,
+  BookmarkMinus,
 } from "lucide-react";
 import { ItineraryTab } from "@/components/ItineraryTab";
 import { MapTab } from "@/components/MapTab";
@@ -30,6 +33,8 @@ const TABS: { id: Tab; label: string; Icon: React.ElementType }[] = [
 interface TripCompanionClientProps {
   trip: TripDetail;
   checklist: ChecklistItem[];
+  readOnly?: boolean;
+  ownerName?: string;
 }
 
 /**
@@ -56,7 +61,12 @@ function getDefaultDayNumber(
  * Manages the active tab and the selected day (shared across tabs so switching
  * tabs preserves the day you were viewing).
  */
-export function TripCompanionClient({ trip, checklist }: TripCompanionClientProps) {
+export function TripCompanionClient({
+  trip,
+  checklist,
+  readOnly = false,
+  ownerName,
+}: TripCompanionClientProps) {
   const [activeTab, setActiveTab] = useState<Tab>("itinerary");
   const [selectedDay, setSelectedDay] = useState<number>(
     () => getDefaultDayNumber(trip.days, trip.start_date, trip.end_date)
@@ -70,6 +80,10 @@ export function TripCompanionClient({ trip, checklist }: TripCompanionClientProp
     ? (tripState.days.flatMap((d) => d.stops).find((s) => s.id === editingStopId) ?? null)
     : null;
 
+  const router = useRouter();
+  const [shareCopied, setShareCopied] = useState(false);
+  const [unsaving, setUnsaving] = useState(false);
+
   function handleLocationSave(stopId: string, address: string, lat: number, lng: number) {
     setTripState((prev) => ({
       ...prev,
@@ -82,6 +96,25 @@ export function TripCompanionClient({ trip, checklist }: TripCompanionClientProp
     }));
     setMapKey((k) => k + 1);
     setEditingStopId(null);
+  }
+
+  async function handleShare() {
+    const res = await fetch(`/api/trips/${tripState.id}/share`, { method: "POST" });
+    if (!res.ok) return;
+    const { url } = await res.json();
+    await navigator.clipboard.writeText(url);
+    setShareCopied(true);
+    setTimeout(() => setShareCopied(false), 2000);
+  }
+
+  async function handleUnsave() {
+    setUnsaving(true);
+    const res = await fetch(`/api/trips/${tripState.id}/follow`, { method: "DELETE" });
+    if (res.ok || res.status === 204) {
+      router.push("/dashboard");
+    } else {
+      setUnsaving(false);
+    }
   }
 
   return (
@@ -100,11 +133,36 @@ export function TripCompanionClient({ trip, checklist }: TripCompanionClientProp
             <h1 className="font-serif text-xl font-semibold text-ink leading-tight truncate">
               {tripState.name}
             </h1>
-            <div className="flex items-center gap-1.5 mt-0.5 text-sm text-muted">
-              <MapPin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
-              <span className="truncate">{tripState.destination}</span>
-            </div>
+            {readOnly ? (
+              <div className="flex items-center gap-1.5 mt-0.5 text-sm text-muted">
+                <span className="truncate">Saved trip · Shared by {ownerName}</span>
+              </div>
+            ) : (
+              <div className="flex items-center gap-1.5 mt-0.5 text-sm text-muted">
+                <MapPin className="h-3.5 w-3.5 shrink-0" aria-hidden="true" />
+                <span className="truncate">{tripState.destination}</span>
+              </div>
+            )}
           </div>
+          {readOnly ? (
+            <button
+              onClick={handleUnsave}
+              disabled={unsaving}
+              className="mt-0.5 ml-auto shrink-0 text-muted hover:text-rust transition-colors disabled:opacity-60"
+              aria-label="Unsave trip"
+            >
+              <BookmarkMinus className="h-5 w-5" />
+            </button>
+          ) : (
+            <button
+              onClick={handleShare}
+              className="mt-0.5 ml-auto shrink-0 text-muted hover:text-ink transition-colors"
+              aria-label={shareCopied ? "Link copied!" : "Share trip"}
+              title={shareCopied ? "Link copied!" : "Share trip"}
+            >
+              <Share2 className="h-5 w-5" />
+            </button>
+          )}
         </div>
       </header>
 
@@ -115,7 +173,7 @@ export function TripCompanionClient({ trip, checklist }: TripCompanionClientProp
             days={tripState.days}
             selectedDay={selectedDay}
             onSelectDay={setSelectedDay}
-            onEditStop={(id) => setEditingStopId(id)}
+            onEditStop={readOnly ? undefined : (id) => setEditingStopId(id)}
           />
         )}
         {activeTab === "map" && (
@@ -126,7 +184,7 @@ export function TripCompanionClient({ trip, checklist }: TripCompanionClientProp
             onSelectDay={setSelectedDay}
             savedViewport={mapViewportRef.current}
             onViewportChange={(vp) => { mapViewportRef.current = vp; }}
-            onEditStop={(id) => setEditingStopId(id)}
+            onEditStop={readOnly ? undefined : (id) => setEditingStopId(id)}
           />
         )}
         {activeTab === "chat" && (
@@ -136,9 +194,11 @@ export function TripCompanionClient({ trip, checklist }: TripCompanionClientProp
             destination={tripState.destination}
           />
         )}
-        {activeTab === "checklist" && (
-          <ChecklistTab tripId={tripState.id} initialItems={checklist} />
-        )}
+        {activeTab === "checklist" && (() => {
+          // readOnly prop will be wired in Task 10; cast until then
+          const ChecklistTabAny = ChecklistTab as React.ComponentType<{ tripId: string; initialItems: ChecklistItem[]; readOnly?: boolean }>;
+          return <ChecklistTabAny tripId={tripState.id} initialItems={checklist} readOnly={readOnly} />;
+        })()}
       </main>
 
       {/* Fixed bottom tab bar */}
@@ -168,7 +228,7 @@ export function TripCompanionClient({ trip, checklist }: TripCompanionClientProp
         </div>
       </nav>
 
-      {editingStop && (
+      {!readOnly && editingStop && (
         <EditLocationModal
           stop={editingStop}
           tripId={tripState.id}

--- a/components/TripCompanionClient.tsx
+++ b/components/TripCompanionClient.tsx
@@ -194,11 +194,9 @@ export function TripCompanionClient({
             destination={tripState.destination}
           />
         )}
-        {activeTab === "checklist" && (() => {
-          // readOnly prop will be wired in Task 10; cast until then
-          const ChecklistTabAny = ChecklistTab as React.ComponentType<{ tripId: string; initialItems: ChecklistItem[]; readOnly?: boolean }>;
-          return <ChecklistTabAny tripId={tripState.id} initialItems={checklist} readOnly={readOnly} />;
-        })()}
+        {activeTab === "checklist" && (
+          <ChecklistTab tripId={tripState.id} initialItems={checklist} readOnly={readOnly} />
+        )}
       </main>
 
       {/* Fixed bottom tab bar */}

--- a/docs/superpowers/specs/2026-03-24-itinerary-sharing-design.md
+++ b/docs/superpowers/specs/2026-03-24-itinerary-sharing-design.md
@@ -1,0 +1,142 @@
+# Itinerary Sharing — Design Spec
+
+**Date:** 2026-03-24
+**Issue:** [#8 — Sharing itineraries](https://github.com/mdeforest/tripforge/issues/8)
+
+## Summary
+
+Allow a trip owner to generate a share link. Any logged-in TripForge user who opens the link can save the trip to their dashboard. Saved trips are live read-only views — followers always see the owner's current itinerary data. Followers get the full companion UI (Itinerary, Map, Chat, Checklist) with edit controls hidden.
+
+---
+
+## 1. Schema
+
+### `Trip` — add `share_token`
+
+```prisma
+share_token String? @unique
+```
+
+- `null` = sharing disabled (default)
+- Generated on demand via `POST /api/trips/[id]/share`; not auto-created at trip creation
+- `@unique` prevents collisions
+
+### New `TripFollow` table
+
+```prisma
+model TripFollow {
+  id          String   @id @default(cuid())
+  follower_id String
+  trip_id     String
+  created_at  DateTime @default(now())
+
+  follower User @relation(fields: [follower_id], references: [id], onDelete: Cascade)
+  trip     Trip @relation(fields: [trip_id], references: [id], onDelete: Cascade)
+
+  @@unique([follower_id, trip_id])
+  @@index([follower_id])
+  @@map("trip_follows")
+}
+```
+
+`onDelete: Cascade` on both FK sides: owner deletes trip → follows removed; follower deletes account → their follows removed.
+
+---
+
+## 2. Share Flow
+
+### Generating a share link
+
+- A "Share" button in the trip header (owner only) calls `POST /api/trips/[id]/share`
+- Generates `crypto.randomUUID()` token, writes to `trip.share_token`, returns full share URL
+- Idempotent: returns existing token if already set
+- "Stop sharing" action: `DELETE /api/trips/[id]/share` → sets `share_token = null`
+  - Existing followers retain their `TripFollow` record and can still view the trip
+  - The link no longer works for new visitors
+
+### Invite page: `/share/[token]`
+
+- Not middleware-protected (the token is the auth mechanism)
+- Unauthenticated visitors: redirect to `/login?callbackUrl=/share/[token]`
+- Page shows: trip name, destination, date range, "Shared by [owner name]"
+- "Save to my trips" button → `POST /api/share/[token]/follow` → redirects to `/trips/[tripId]`
+
+**Edge cases:**
+- Token not found → 404
+- Owner visits their own share link → "You own this trip" with link to open it
+- Already following → "Already saved" (disabled button) with link to open it
+
+---
+
+## 3. Trip Page — Owner vs. Follower
+
+### `/trips/[id]/page.tsx`
+
+Replace the hard ownership check with:
+1. Is viewer the owner? → full access, `isOwner: true`
+2. Does a `TripFollow` record exist for `(follower_id, trip_id)`? → read-only access, `isOwner: false`
+3. Neither → `notFound()`
+
+`isOwner` is passed as a prop to `TripCompanionClient`.
+
+### Read-only UI differences for followers
+
+| Location | Owner sees | Follower sees |
+|---|---|---|
+| Header subtitle | Destination | "Saved trip · Shared by [name]" |
+| Header actions | Share button | Unsave button |
+| Itinerary tab | Edit location links | Hidden |
+| Map tab | Edit location popups | Hidden |
+| Chat tab | Full AI chat | Full AI chat (independent session) |
+| Checklist tab | Full management | Read-only (checkboxes disabled, no generate/add) |
+
+`isOwner` threads through: `TripCompanionClient` → `ItineraryTab`, `MapTab`, `ChecklistTab`. `ChatTab` does not need it.
+
+**Unsave:** Followers can remove the trip from their dashboard via an "Unsave" button, which calls `DELETE /api/trips/[id]/follow` and redirects to `/dashboard`.
+
+---
+
+## 4. Dashboard
+
+Parallel queries:
+
+```ts
+const [ownedTrips, followedTrips] = await Promise.all([
+  prisma.trip.findMany({ where: { user_id }, orderBy: ... }),
+  prisma.tripFollow.findMany({
+    where: { follower_id: userId },
+    include: { trip: { include: { user: { select: { name: true } } } } },
+    orderBy: { created_at: "desc" },
+  }),
+]);
+```
+
+- Renders **"My Trips"** section (owned) and **"Saved Trips"** section (followed) when followed trips exist
+- If no followed trips: dashboard looks identical to today
+- `TripCard` gains an optional `sharedBy?: string` prop — renders a "Shared by [name]" attribution line when present
+
+---
+
+## 5. API Routes
+
+| Method | Path | Auth | Action |
+|---|---|---|---|
+| `POST` | `/api/trips/[id]/share` | Owner only | Generate `share_token`, return share URL |
+| `DELETE` | `/api/trips/[id]/share` | Owner only | Set `share_token = null` |
+| `GET` | `/api/share/[token]` | Public | Return trip preview for invite page |
+| `POST` | `/api/share/[token]/follow` | Logged-in | Create `TripFollow`, return `{ tripId }` |
+| `DELETE` | `/api/trips/[id]/follow` | Follower only | Delete `TripFollow`, return 204 |
+
+**Existing route update:**
+- `POST /api/trips/[id]/chat`: relax ownership check to allow followers (owner-or-follower pattern)
+
+---
+
+## 6. Testing
+
+- Unit tests for all 5 new API routes (auth checks, idempotency, 404 on bad token)
+- Unit test: `/share/[token]` page renders trip preview and "Save" button
+- Unit test: `/trips/[id]` page renders read-only UI for follower (no edit links)
+- Unit test: dashboard renders "Saved Trips" section for users with follows
+- Unit test: `TripCard` renders `sharedBy` attribution when prop is present
+- Existing trip page tests remain green (owner path unchanged)

--- a/docs/superpowers/specs/2026-03-24-itinerary-sharing-design.md
+++ b/docs/superpowers/specs/2026-03-24-itinerary-sharing-design.md
@@ -18,8 +18,9 @@ share_token String? @unique
 ```
 
 - `null` = sharing disabled (default)
-- Generated on demand via `POST /api/trips/[id]/share`; not auto-created at trip creation
-- `@unique` prevents collisions
+- Token format: `crypto.randomBytes(32).toString("hex")` — 256-bit entropy, URL-safe
+- Generated on demand; not auto-created at trip creation
+- **Note:** The share token generation route must use the default Node.js runtime, not the edge runtime. `crypto.randomBytes` is not available on the edge.
 
 ### New `TripFollow` table
 
@@ -35,6 +36,7 @@ model TripFollow {
 
   @@unique([follower_id, trip_id])
   @@index([follower_id])
+  @@index([trip_id])
   @@map("trip_follows")
 }
 ```
@@ -48,51 +50,138 @@ model TripFollow {
 ### Generating a share link
 
 - A "Share" button in the trip header (owner only) calls `POST /api/trips/[id]/share`
-- Generates `crypto.randomUUID()` token, writes to `trip.share_token`, returns full share URL
-- Idempotent: returns existing token if already set
-- "Stop sharing" action: `DELETE /api/trips/[id]/share` → sets `share_token = null`
-  - Existing followers retain their `TripFollow` record and can still view the trip
-  - The link no longer works for new visitors
+- **Idempotent:** if `trip.share_token` is already set, return the existing token as-is (no regeneration — would invalidate shared links). Returns `{ url: "${NEXTAUTH_URL}/share/${token}" }`. Base URL sourced from `process.env.NEXTAUTH_URL`.
+- If `share_token` is `null`, generate a new token via `crypto.randomBytes(32).toString("hex")`, write it, then return `{ url }`.
+- "Stop sharing" → `DELETE /api/trips/[id]/share`: sets `share_token = null`.
+  - **Does not delete existing `TripFollow` records.** Followers retain access to `/trips/[id]` after revocation — they can still view the trip and unsave it independently. Revoking the share link stops new saves; it does not evict existing followers.
 
-### Invite page: `/share/[token]`
+### Middleware
 
-- Not middleware-protected (the token is the auth mechanism)
-- Unauthenticated visitors: redirect to `/login?callbackUrl=/share/[token]`
-- Page shows: trip name, destination, date range, "Shared by [owner name]"
-- "Save to my trips" button → `POST /api/share/[token]/follow` → redirects to `/trips/[tripId]`
+`/share/*` is **not** in the current middleware matcher (`/dashboard/:path*`, `/trips/:path*`). **Middleware stays unchanged.** Auth enforcement for `/share/[token]` is done with a manual server-side redirect inside the page component.
 
-**Edge cases:**
-- Token not found → 404
-- Owner visits their own share link → "You own this trip" with link to open it
-- Already following → "Already saved" (disabled button) with link to open it
+### Route group and layout for `/share/[token]`
+
+The invite page lives at `app/share/[token]/page.tsx` — **outside all route groups** (not in `(app)/` or `(auth)/`). A minimal standalone layout at `app/share/layout.tsx` (no NavBar, no authenticated wrapper).
+
+### Invite page: `app/share/[token]/page.tsx`
+
+- Unauthenticated: `getServerSession` returns null → `redirect(\`/login?callbackUrl=/share/${token}\`)`
+- Authenticated: fetches `GET /api/share/[token]` which returns `{ name, destination, start_date, end_date, ownerName }` — no stop details
+- `ownerName` = `trip.user.name` (the trip owner's name, not the follower's); falls back to `"a TripForge user"` if empty string
+
+**"Save to my trips" button:**
+- Client calls `POST /api/share/[token]/follow`
+- API returns `200 { tripId }` (idempotent — same 200 on repeat calls; implemented via `upsert` or `findUnique` + conditional `create`)
+- Client calls `router.push(\`/trips/${tripId}\`)` after success
+- If token not found or revoked (404): invite page shows error message "This share link is no longer active" — no redirect attempted
+
+**"Unsave" button (in the trip page header for followers):**
+- Client calls `DELETE /api/trips/[id]/follow`
+- API returns 204 if `TripFollow` record exists and was deleted; 204 no-op if `TripFollow` not found (never 500); 404 if the `trip_id` itself does not exist in the DB
+- Client calls `router.push("/dashboard")` after success
+
+**Edge cases on the invite page:**
+- Token not found or revoked → error message: "This share link is no longer active"
+- Owner visits their own share link → "You own this trip" with link to `/trips/[tripId]`
+- Already following → "Already saved" (disabled button) with link to `/trips/[tripId]`
 
 ---
 
 ## 3. Trip Page — Owner vs. Follower
 
-### `/trips/[id]/page.tsx`
+### Updated Prisma query in `app/(app)/trips/[id]/page.tsx`
 
-Replace the hard ownership check with:
-1. Is viewer the owner? → full access, `isOwner: true`
-2. Does a `TripFollow` record exist for `(follower_id, trip_id)`? → read-only access, `isOwner: false`
-3. Neither → `notFound()`
+The existing `prisma.trip.findUnique` call must be extended to include the owner's name:
 
-`isOwner` is passed as a prop to `TripCompanionClient`.
+```ts
+const trip = await prisma.trip.findUnique({
+  where: { id: params.id },
+  select: {
+    id: true,
+    user_id: true,
+    name: true,
+    destination: true,
+    start_date: true,
+    end_date: true,
+    user: { select: { name: true } },   // ← ADD THIS
+    days: { /* existing shape unchanged */ },
+  },
+});
+```
 
-### Read-only UI differences for followers
+### Updated access control
 
-| Location | Owner sees | Follower sees |
+Replace the current `if (!trip || trip.user_id !== session.user.id) notFound()` with:
+
+```ts
+if (!trip) notFound();
+
+const isOwner = trip.user_id === session.user.id;
+
+const follow = !isOwner
+  ? await prisma.tripFollow.findUnique({
+      where: { follower_id_trip_id: { follower_id: session.user.id, trip_id: trip.id } },
+    })
+  : null;
+
+if (!isOwner && !follow) notFound();
+
+const ownerName: string | undefined = isOwner
+  ? undefined
+  : (trip.user.name || "a TripForge user");
+```
+
+Both `readOnly={!isOwner}` and `ownerName={ownerName}` are passed to `TripCompanionClient`. `ownerName` is `undefined` for owners (not needed in the owner UI).
+
+### Component prop changes
+
+**`TripCompanionClient`:**
+```ts
+interface TripCompanionClientProps {
+  trip: TripDetail;
+  checklist: ChecklistItem[];
+  readOnly?: boolean;       // default false
+  ownerName?: string;       // populated only for followers
+}
+```
+
+- When `readOnly=true`: does **not** pass `onEditStop` to `ItineraryTab` or `MapTab`
+- `EditLocationModal` is conditionally rendered: `{!readOnly && editingStop && <EditLocationModal ... />}`
+- Header shows "Saved trip · Shared by [ownerName]" and Unsave button instead of Share button when `readOnly=true`
+
+**`ItineraryTab`:** `onEditStop` becomes optional (`onEditStop?: (id: string) => void`); edit links only rendered when callback is provided.
+
+**`MapTab`:** Same — `onEditStop` optional; edit popups only shown when callback is provided.
+
+**`ChecklistTab`:**
+```ts
+interface ChecklistTabProps {
+  tripId: string;
+  initialItems: ChecklistItem[];
+  readOnly?: boolean;       // default false
+}
+```
+When `readOnly=true`: all mutation controls are hidden/disabled — checkboxes disabled, "Generate packing list" button hidden, "Add item" form hidden, delete buttons hidden. No mutation API calls are attempted. The API (`POST/PATCH/DELETE /api/trips/[id]/checklist`) still enforces owner-only for mutations as a defense-in-depth backstop: "follower PATCH attempts are prevented by both the disabled UI and the 403 from the API."
+
+### Follower checklist state
+
+Followers see **the owner's checklist items** (fetched identically to the owner path — items are scoped to `trip_id`). No schema change needed.
+
+### Geocoding backfill
+
+The existing geocoding backfill (writes coordinates back to `Stop` rows) runs for both owners and followers. This is intentional: the backfill only fills in missing geocoordinate data and is idempotent. A follower triggering a write to rows they don't own is acceptable because the data (coordinates) is objective and non-destructive.
+
+### Read-only UI summary
+
+| Location | Owner (`readOnly=false`) | Follower (`readOnly=true`) |
 |---|---|---|
-| Header subtitle | Destination | "Saved trip · Shared by [name]" |
+| Header subtitle | Destination | "Saved trip · Shared by [ownerName]" |
 | Header actions | Share button | Unsave button |
-| Itinerary tab | Edit location links | Hidden |
-| Map tab | Edit location popups | Hidden |
+| Itinerary tab | Edit location links | Hidden (no `onEditStop` prop) |
+| Map tab | Edit location popups | Hidden (no `onEditStop` prop) |
+| Edit location modal | Rendered when stop selected | Never rendered |
 | Chat tab | Full AI chat | Full AI chat (independent session) |
-| Checklist tab | Full management | Read-only (checkboxes disabled, no generate/add) |
-
-`isOwner` threads through: `TripCompanionClient` → `ItineraryTab`, `MapTab`, `ChecklistTab`. `ChatTab` does not need it.
-
-**Unsave:** Followers can remove the trip from their dashboard via an "Unsave" button, which calls `DELETE /api/trips/[id]/follow` and redirects to `/dashboard`.
+| Checklist tab | Full management | Read-only (all mutation controls hidden) |
 
 ---
 
@@ -106,14 +195,16 @@ const [ownedTrips, followedTrips] = await Promise.all([
   prisma.tripFollow.findMany({
     where: { follower_id: userId },
     include: { trip: { include: { user: { select: { name: true } } } } },
+    // trip.user.name = the trip owner's name, not the follower's
     orderBy: { created_at: "desc" },
   }),
 ]);
 ```
 
 - Renders **"My Trips"** section (owned) and **"Saved Trips"** section (followed) when followed trips exist
-- If no followed trips: dashboard looks identical to today
-- `TripCard` gains an optional `sharedBy?: string` prop — renders a "Shared by [name]" attribution line when present
+- "Saved Trips" hidden when `followedTrips.length === 0`
+- Existing empty-state UI (Compass icon, "No trips yet" CTA) only renders when **both** `ownedTrips.length === 0` **and** `followedTrips.length === 0`
+- `TripCard` gains an optional `sharedBy?: string` prop — renders "Shared by [name]" when present. Value: `follow.trip.user.name || "a TripForge user"`.
 
 ---
 
@@ -121,22 +212,50 @@ const [ownedTrips, followedTrips] = await Promise.all([
 
 | Method | Path | Auth | Action |
 |---|---|---|---|
-| `POST` | `/api/trips/[id]/share` | Owner only | Generate `share_token`, return share URL |
-| `DELETE` | `/api/trips/[id]/share` | Owner only | Set `share_token = null` |
-| `GET` | `/api/share/[token]` | Public | Return trip preview for invite page |
-| `POST` | `/api/share/[token]/follow` | Logged-in | Create `TripFollow`, return `{ tripId }` |
-| `DELETE` | `/api/trips/[id]/follow` | Follower only | Delete `TripFollow`, return 204 |
+| `POST` | `/api/trips/[id]/share` | Owner only | Generate token (if null), return `{ url }` |
+| `DELETE` | `/api/trips/[id]/share` | Owner only | Set `share_token = null`; keep TripFollow records |
+| `GET` | `/api/share/[token]` | Public | Return `{ name, destination, start_date, end_date, ownerName }`; 404 if not found |
+| `POST` | `/api/share/[token]/follow` | Logged-in | Upsert `TripFollow`, return `200 { tripId }`; 404 if token not found |
+| `DELETE` | `/api/trips/[id]/follow` | Logged-in | Delete `TripFollow` if exists → 204; no `TripFollow` row → 204 (no-op); `trip_id` not in DB → 404 |
 
-**Existing route update:**
-- `POST /api/trips/[id]/chat`: relax ownership check to allow followers (owner-or-follower pattern)
+### Existing routes to update
+
+- **`POST /api/trips/[id]/chat`**: relax to owner-or-follower
+- **`GET /api/trips/[id]`**: relax to owner-or-follower (not on rendering critical path — trip page queries Prisma directly)
+- **Checklist routes** (`/api/trips/[id]/checklist`):
+  - `GET`: relax using new `getAuthorizedOrFollowerTrip()` helper (return type: `{ session, trip, isOwner: boolean } | { error: NextResponse }`)
+  - `POST`, `PATCH`, `DELETE`: keep existing `getAuthorizedTrip()` (owner-only); existing tests unaffected
 
 ---
 
 ## 6. Testing
 
-- Unit tests for all 5 new API routes (auth checks, idempotency, 404 on bad token)
-- Unit test: `/share/[token]` page renders trip preview and "Save" button
-- Unit test: `/trips/[id]` page renders read-only UI for follower (no edit links)
-- Unit test: dashboard renders "Saved Trips" section for users with follows
-- Unit test: `TripCard` renders `sharedBy` attribution when prop is present
-- Existing trip page tests remain green (owner path unchanged)
+**`tests/setup.ts`:** Add `prisma.tripFollow` to the global Prisma mock with methods: `findUnique`, `create`, `findMany`, `delete`, `deleteMany`, `upsert`.
+
+**New API routes (5 routes):**
+- `POST /api/trips/[id]/share`: creates token, returns URL; returns same URL on second call; 403 for non-owner
+- `DELETE /api/trips/[id]/share`: nulls token; does not delete follows; 403 for non-owner
+- `GET /api/share/[token]`: returns preview fields; 404 on unknown/revoked token
+- `POST /api/share/[token]/follow`: creates follow, returns `200 { tripId }`; returns `200 { tripId }` on repeat call (idempotent); 404 on bad token; 401 if not logged in
+- `DELETE /api/trips/[id]/follow`: 204 when follow record exists; 204 when follow record not found (no-op); 404 when `trip_id` does not exist
+
+**Invite page (`app/share/[token]/page.tsx`):**
+- Redirects unauthenticated users to `/login?callbackUrl=/share/[token]`
+- Shows preview + "Save to my trips" for authenticated non-owner non-follower
+- Shows error message ("This share link is no longer active") for revoked/unknown token
+- Shows "You own this trip" + link to `/trips/[tripId]` for owner
+- Shows "Already saved" + link to `/trips/[tripId]` for existing follower
+
+**Trip page (`app/(app)/trips/[id]/page.tsx`):**
+- Renders read-only UI for follower: no edit links, no checklist mutation controls, no modal
+- `notFound` for non-owner non-follower
+- Existing owner tests remain green (owner path unchanged)
+
+**Dashboard:**
+- Renders "Saved Trips" section when follows exist
+- Empty-state CTA only when both owned and followed trips are empty
+- `TripCard` renders `sharedBy` attribution when prop is present
+
+**Component unit tests:**
+- `ChecklistTab` with `readOnly=true`: mutation controls not rendered
+- `TripCompanionClient` with `readOnly=true`: `EditLocationModal` not rendered; `onEditStop` not passed to children

--- a/prisma/schema.prisma
+++ b/prisma/schema.prisma
@@ -23,6 +23,7 @@ model User {
   created_at    DateTime  @default(now())
 
   trips Trip[]
+  trip_follows TripFollow[] @relation("UserFollows")
 
   // NextAuth adapter fields
   emailVerified DateTime?
@@ -50,6 +51,9 @@ model Trip {
   parsed_data Json?
   packing_list Json?
   created_at  DateTime  @default(now())
+
+  share_token  String?     @unique
+  trip_follows TripFollow[]
 
   user           User            @relation(fields: [user_id], references: [id], onDelete: Cascade)
   days           Day[]
@@ -174,4 +178,23 @@ model VerificationToken {
 
   @@unique([identifier, token])
   @@map("verification_tokens")
+}
+
+// ─────────────────────────────────────────────────────────────────────────────
+// TRIP FOLLOWS
+// Tracks which users are following (have saved) a shared trip.
+// ─────────────────────────────────────────────────────────────────────────────
+model TripFollow {
+  id          String   @id @default(cuid())
+  follower_id String
+  trip_id     String
+  created_at  DateTime @default(now())
+
+  follower User @relation("UserFollows", fields: [follower_id], references: [id], onDelete: Cascade)
+  trip     Trip @relation(fields: [trip_id], references: [id], onDelete: Cascade)
+
+  @@unique([follower_id, trip_id])
+  @@index([follower_id])
+  @@index([trip_id])
+  @@map("trip_follows")
 }

--- a/tests/setup.ts
+++ b/tests/setup.ts
@@ -48,6 +48,7 @@ vi.mock("@/lib/prisma", () => ({
     },
     trip: {
       findMany: vi.fn(),
+      findFirst: vi.fn(),
       findUnique: vi.fn(),
       create: vi.fn(),
       update: vi.fn(),
@@ -72,6 +73,14 @@ vi.mock("@/lib/prisma", () => ({
       createMany: vi.fn(),
       update: vi.fn(),
       delete: vi.fn(),
+    },
+    tripFollow: {
+      findUnique: vi.fn(),
+      findMany: vi.fn(),
+      create: vi.fn(),
+      upsert: vi.fn(),
+      delete: vi.fn(),
+      deleteMany: vi.fn(),
     },
   },
 }));

--- a/tests/unit/api/chat.test.ts
+++ b/tests/unit/api/chat.test.ts
@@ -150,3 +150,45 @@ describe("POST /api/trips/[id]/chat", () => {
     expect(body.code).toBe("INTERNAL_ERROR");
   });
 });
+
+describe("POST /api/trips/[id]/chat — follower access", () => {
+  beforeEach(() => {
+    vi.resetModules();
+    mockGenerateContentStream.mockReset();
+    vi.mocked(getServerSession).mockReset();
+    vi.mocked(prisma.trip.findUnique).mockReset();
+  });
+
+  it("returns streaming response for a follower", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "follower-1" } } as never);
+    vi.mocked(prisma.trip.findUnique).mockResolvedValue({ ...TRIP_DB, user_id: "owner-1" } as never);
+    vi.mocked(prisma.tripFollow.findUnique).mockResolvedValue({
+      id: "f1", follower_id: "follower-1", trip_id: "trip-1", created_at: new Date(),
+    } as never);
+    mockGenerateContentStream.mockResolvedValue(makeStream("Hello!"));
+
+    const { POST } = await import("@/app/api/trips/[id]/chat/route");
+    const req = new Request("http://localhost/api/trips/trip-1/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "Hello" }] }),
+    });
+    const res = await POST(req, { params: { id: "trip-1" } });
+    expect(res.status).not.toBe(403);
+  });
+
+  it("returns 403 for authenticated non-owner non-follower", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "stranger-1" } } as never);
+    vi.mocked(prisma.trip.findUnique).mockResolvedValue({ ...TRIP_DB, user_id: "owner-1" } as never);
+    vi.mocked(prisma.tripFollow.findUnique).mockResolvedValue(null);
+
+    const { POST } = await import("@/app/api/trips/[id]/chat/route");
+    const req = new Request("http://localhost/api/trips/trip-1/chat", {
+      method: "POST",
+      headers: { "Content-Type": "application/json" },
+      body: JSON.stringify({ messages: [{ role: "user", content: "Hello" }] }),
+    });
+    const res = await POST(req, { params: { id: "trip-1" } });
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/unit/api/share-follow.test.ts
+++ b/tests/unit/api/share-follow.test.ts
@@ -1,0 +1,59 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+import { getServerSession } from "next-auth";
+import { prisma } from "@/lib/prisma";
+
+const SESSION = { user: { id: "follower-1" } };
+const TRIP = { id: "trip-1", user_id: "owner-1" };
+
+function makeRequest() {
+  return new Request("http://localhost/api/share/abc123/follow", { method: "POST" });
+}
+
+describe("POST /api/share/[token]/follow", () => {
+  beforeEach(() => {
+    vi.mocked(getServerSession).mockResolvedValue(SESSION as never);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    const { POST } = await import("@/app/api/share/[token]/follow/route");
+    const res = await POST(makeRequest(), { params: { token: "abc123" } });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when token not found", async () => {
+    vi.mocked(prisma.trip.findFirst).mockResolvedValue(null);
+    const { POST } = await import("@/app/api/share/[token]/follow/route");
+    const res = await POST(makeRequest(), { params: { token: "bad-token" } });
+    expect(res.status).toBe(404);
+  });
+
+  it("upserts TripFollow and returns { tripId }", async () => {
+    vi.mocked(prisma.trip.findFirst).mockResolvedValue(TRIP as never);
+    vi.mocked(prisma.tripFollow.upsert).mockResolvedValue({
+      id: "f1", follower_id: "follower-1", trip_id: "trip-1", created_at: new Date(),
+    } as never);
+    const { POST } = await import("@/app/api/share/[token]/follow/route");
+    const res = await POST(makeRequest(), { params: { token: "abc123" } });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.tripId).toBe("trip-1");
+    expect(prisma.tripFollow.upsert).toHaveBeenCalledOnce();
+  });
+
+  it("returns 200 on repeat call (idempotent via upsert)", async () => {
+    vi.mocked(prisma.trip.findFirst).mockResolvedValue(TRIP as never);
+    vi.mocked(prisma.tripFollow.upsert).mockResolvedValue({
+      id: "f1", follower_id: "follower-1", trip_id: "trip-1", created_at: new Date(),
+    } as never);
+    const { POST } = await import("@/app/api/share/[token]/follow/route");
+    const res1 = await POST(makeRequest(), { params: { token: "abc123" } });
+    const res2 = await POST(makeRequest(), { params: { token: "abc123" } });
+    expect(res1.status).toBe(200);
+    expect(res2.status).toBe(200);
+  });
+});

--- a/tests/unit/api/share-get.test.ts
+++ b/tests/unit/api/share-get.test.ts
@@ -1,0 +1,48 @@
+import { describe, it, expect, vi } from "vitest";
+import { prisma } from "@/lib/prisma";
+
+const TRIP = {
+  id: "trip-1",
+  name: "Italy Trip",
+  destination: "Rome, Italy",
+  start_date: new Date("2026-05-01T12:00:00Z"),
+  end_date: new Date("2026-05-07T12:00:00Z"),
+  user: { name: "Matt" },
+};
+
+function makeRequest() {
+  return new Request("http://localhost/api/share/abc123");
+}
+
+describe("GET /api/share/[token]", () => {
+  it("returns 404 when token not found", async () => {
+    vi.mocked(prisma.trip.findFirst).mockResolvedValue(null);
+    const { GET } = await import("@/app/api/share/[token]/route");
+    const res = await GET(makeRequest(), { params: { token: "bad-token" } });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns preview fields for a valid token", async () => {
+    vi.mocked(prisma.trip.findFirst).mockResolvedValue(TRIP as never);
+    const { GET } = await import("@/app/api/share/[token]/route");
+    const res = await GET(makeRequest(), { params: { token: "abc123" } });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body).toMatchObject({
+      name: "Italy Trip",
+      destination: "Rome, Italy",
+      ownerName: "Matt",
+      tripId: "trip-1",
+    });
+    expect(body.start_date).toBe("2026-05-01");
+    expect(body.end_date).toBe("2026-05-07");
+  });
+
+  it("falls back to 'a TripForge user' when owner name is empty", async () => {
+    vi.mocked(prisma.trip.findFirst).mockResolvedValue({ ...TRIP, user: { name: "" } } as never);
+    const { GET } = await import("@/app/api/share/[token]/route");
+    const res = await GET(makeRequest(), { params: { token: "abc123" } });
+    const body = await res.json();
+    expect(body.ownerName).toBe("a TripForge user");
+  });
+});

--- a/tests/unit/api/trip-follow-delete.test.ts
+++ b/tests/unit/api/trip-follow-delete.test.ts
@@ -1,0 +1,54 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+import { getServerSession } from "next-auth";
+import { prisma } from "@/lib/prisma";
+
+const SESSION = { user: { id: "follower-1" } };
+const TRIP = { id: "trip-1" };
+const FOLLOW = { id: "f1", follower_id: "follower-1", trip_id: "trip-1", created_at: new Date() };
+
+function makeRequest() {
+  return new Request("http://localhost/api/trips/trip-1/follow", { method: "DELETE" });
+}
+
+describe("DELETE /api/trips/[id]/follow", () => {
+  beforeEach(() => {
+    vi.mocked(getServerSession).mockResolvedValue(SESSION as never);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    const { DELETE } = await import("@/app/api/trips/[id]/follow/route");
+    const res = await DELETE(makeRequest(), { params: { id: "trip-1" } });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when trip does not exist", async () => {
+    vi.mocked(prisma.trip.findUnique).mockResolvedValue(null);
+    const { DELETE } = await import("@/app/api/trips/[id]/follow/route");
+    const res = await DELETE(makeRequest(), { params: { id: "trip-1" } });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 204 and deletes follow when it exists", async () => {
+    vi.mocked(prisma.trip.findUnique).mockResolvedValue(TRIP as never);
+    vi.mocked(prisma.tripFollow.findUnique).mockResolvedValue(FOLLOW as never);
+    vi.mocked(prisma.tripFollow.delete).mockResolvedValue(FOLLOW as never);
+    const { DELETE } = await import("@/app/api/trips/[id]/follow/route");
+    const res = await DELETE(makeRequest(), { params: { id: "trip-1" } });
+    expect(res.status).toBe(204);
+    expect(prisma.tripFollow.delete).toHaveBeenCalled();
+  });
+
+  it("returns 204 no-op when follow record does not exist", async () => {
+    vi.mocked(prisma.trip.findUnique).mockResolvedValue(TRIP as never);
+    vi.mocked(prisma.tripFollow.findUnique).mockResolvedValue(null);
+    const { DELETE } = await import("@/app/api/trips/[id]/follow/route");
+    const res = await DELETE(makeRequest(), { params: { id: "trip-1" } });
+    expect(res.status).toBe(204);
+    expect(prisma.tripFollow.delete).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/api/trip-share.test.ts
+++ b/tests/unit/api/trip-share.test.ts
@@ -1,0 +1,96 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+
+import { getServerSession } from "next-auth";
+import { prisma } from "@/lib/prisma";
+
+const SESSION = { user: { id: "user-1" } };
+const TRIP_OWNED = { id: "trip-1", user_id: "user-1", share_token: null };
+const TRIP_WITH_TOKEN = { id: "trip-1", user_id: "user-1", share_token: "existing-token-abc" };
+
+function makeRequest(method: string) {
+  return new Request("http://localhost/api/trips/trip-1/share", { method });
+}
+
+describe("POST /api/trips/[id]/share", () => {
+  beforeEach(() => {
+    vi.mocked(getServerSession).mockResolvedValue(SESSION as never);
+    process.env.NEXTAUTH_URL = "https://app.example.com";
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    const { POST } = await import("@/app/api/trips/[id]/share/route");
+    const res = await POST(makeRequest("POST"), { params: { id: "trip-1" } });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 404 when trip not found", async () => {
+    vi.mocked(prisma.trip.findUnique).mockResolvedValue(null);
+    const { POST } = await import("@/app/api/trips/[id]/share/route");
+    const res = await POST(makeRequest("POST"), { params: { id: "trip-1" } });
+    expect(res.status).toBe(404);
+  });
+
+  it("returns 403 when not the trip owner", async () => {
+    vi.mocked(prisma.trip.findUnique).mockResolvedValue({ ...TRIP_OWNED, user_id: "other" } as never);
+    const { POST } = await import("@/app/api/trips/[id]/share/route");
+    const res = await POST(makeRequest("POST"), { params: { id: "trip-1" } });
+    expect(res.status).toBe(403);
+  });
+
+  it("generates a token and returns URL when share_token is null", async () => {
+    vi.mocked(prisma.trip.findUnique).mockResolvedValue(TRIP_OWNED as never);
+    vi.mocked(prisma.trip.update).mockResolvedValue({ ...TRIP_OWNED, share_token: "new-token" } as never);
+    const { POST } = await import("@/app/api/trips/[id]/share/route");
+    const res = await POST(makeRequest("POST"), { params: { id: "trip-1" } });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.url).toContain("/share/");
+    expect(prisma.trip.update).toHaveBeenCalled();
+  });
+
+  it("returns existing URL without calling update when token already set (idempotent)", async () => {
+    vi.mocked(prisma.trip.findUnique).mockResolvedValue(TRIP_WITH_TOKEN as never);
+    const { POST } = await import("@/app/api/trips/[id]/share/route");
+    const res = await POST(makeRequest("POST"), { params: { id: "trip-1" } });
+    expect(res.status).toBe(200);
+    const body = await res.json();
+    expect(body.url).toContain("existing-token-abc");
+    expect(prisma.trip.update).not.toHaveBeenCalled();
+  });
+});
+
+describe("DELETE /api/trips/[id]/share", () => {
+  beforeEach(() => {
+    vi.mocked(getServerSession).mockResolvedValue(SESSION as never);
+  });
+
+  it("returns 401 when not authenticated", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    const { DELETE } = await import("@/app/api/trips/[id]/share/route");
+    const res = await DELETE(makeRequest("DELETE"), { params: { id: "trip-1" } });
+    expect(res.status).toBe(401);
+  });
+
+  it("returns 403 when not the trip owner", async () => {
+    vi.mocked(prisma.trip.findUnique).mockResolvedValue({ ...TRIP_OWNED, user_id: "other" } as never);
+    const { DELETE } = await import("@/app/api/trips/[id]/share/route");
+    const res = await DELETE(makeRequest("DELETE"), { params: { id: "trip-1" } });
+    expect(res.status).toBe(403);
+  });
+
+  it("nulls share_token and does not touch TripFollow records", async () => {
+    vi.mocked(prisma.trip.findUnique).mockResolvedValue(TRIP_WITH_TOKEN as never);
+    vi.mocked(prisma.trip.update).mockResolvedValue({ ...TRIP_WITH_TOKEN, share_token: null } as never);
+    const { DELETE } = await import("@/app/api/trips/[id]/share/route");
+    const res = await DELETE(makeRequest("DELETE"), { params: { id: "trip-1" } });
+    expect(res.status).toBe(200);
+    expect(prisma.trip.update).toHaveBeenCalledWith(
+      expect.objectContaining({ data: { share_token: null } })
+    );
+    expect(prisma.tripFollow.deleteMany).not.toHaveBeenCalled();
+  });
+});

--- a/tests/unit/api/trips-get.test.ts
+++ b/tests/unit/api/trips-get.test.ts
@@ -99,3 +99,23 @@ describe("GET /api/trips/[id]", () => {
     expect(body.code).toBe("INTERNAL_ERROR");
   });
 });
+
+describe("GET /api/trips/[id] — follower access", () => {
+  it("returns 200 for a follower", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "follower-1" } } as never);
+    vi.mocked(prisma.trip.findUnique).mockResolvedValue({ ...MOCK_TRIP, user_id: "owner-1" } as never);
+    vi.mocked(prisma.tripFollow.findUnique).mockResolvedValue({
+      id: "f1", follower_id: "follower-1", trip_id: "trip-1", created_at: new Date(),
+    } as never);
+    const res = await GET(makeRequest("trip-1"), { params: { id: "trip-1" } });
+    expect(res.status).toBe(200);
+  });
+
+  it("returns 403 for authenticated non-owner non-follower", async () => {
+    vi.mocked(getServerSession).mockResolvedValue({ user: { id: "stranger-1" } } as never);
+    vi.mocked(prisma.trip.findUnique).mockResolvedValue({ ...MOCK_TRIP, user_id: "owner-1" } as never);
+    vi.mocked(prisma.tripFollow.findUnique).mockResolvedValue(null);
+    const res = await GET(makeRequest("trip-1"), { params: { id: "trip-1" } });
+    expect(res.status).toBe(403);
+  });
+});

--- a/tests/unit/components/ChecklistTab.test.tsx
+++ b/tests/unit/components/ChecklistTab.test.tsx
@@ -262,3 +262,32 @@ describe("ChecklistTab", () => {
     );
   });
 });
+
+describe("ChecklistTab — readOnly mode", () => {
+  it("disables all checkboxes when readOnly=true", () => {
+    render(<ChecklistTab {...DEFAULT_PROPS} readOnly={true} />);
+    screen.getAllByRole("checkbox").forEach((cb) => expect(cb).toBeDisabled());
+  });
+
+  it("hides the Generate packing list button when readOnly=true", () => {
+    render(<ChecklistTab tripId="trip-1" initialItems={[]} readOnly={true} />);
+    expect(screen.queryByRole("button", { name: /generate/i })).not.toBeInTheDocument();
+  });
+
+  it("hides the Add item section when readOnly=true", () => {
+    render(<ChecklistTab {...DEFAULT_PROPS} readOnly={true} />);
+    // The "Add item" button or form input should not be present
+    expect(screen.queryByPlaceholderText(/add/i)).not.toBeInTheDocument();
+    expect(screen.queryByRole("button", { name: /add/i })).not.toBeInTheDocument();
+  });
+
+  it("hides delete buttons when readOnly=true", () => {
+    render(<ChecklistTab {...DEFAULT_PROPS} readOnly={true} />);
+    expect(screen.queryAllByRole("button", { name: /delete/i })).toHaveLength(0);
+  });
+
+  it("shows all controls normally when readOnly is omitted", () => {
+    render(<ChecklistTab {...DEFAULT_PROPS} />);
+    screen.getAllByRole("checkbox").forEach((cb) => expect(cb).not.toBeDisabled());
+  });
+});

--- a/tests/unit/components/Dashboard.test.tsx
+++ b/tests/unit/components/Dashboard.test.tsx
@@ -42,6 +42,7 @@ const MOCK_TRIPS = [
 describe("DashboardPage", () => {
   beforeEach(() => {
     vi.mocked(getServerSession).mockResolvedValue(MOCK_SESSION as never);
+    vi.mocked(prisma.tripFollow.findMany).mockResolvedValue([]);
   });
 
   // ── Empty state ────────────────────────────────────────────────────────────
@@ -120,5 +121,67 @@ describe("DashboardPage", () => {
     }
 
     expect(vi.mocked(redirect)).toHaveBeenCalledWith("/login");
+  });
+});
+
+const MOCK_FOLLOWS = [
+  {
+    id: "follow-1",
+    follower_id: "user-1",
+    trip_id: "trip-3",
+    created_at: new Date(),
+    trip: {
+      id: "trip-3",
+      name: "Tokyo Adventure",
+      destination: "Tokyo, Japan",
+      start_date: null,
+      end_date: null,
+      created_at: new Date(),
+      user: { name: "Alex" },
+    },
+  },
+];
+
+describe("DashboardPage — Saved Trips", () => {
+  beforeEach(() => {
+    vi.mocked(getServerSession).mockResolvedValue(MOCK_SESSION as never);
+  });
+
+  it("renders 'Saved Trips' section with attribution when user has follows", async () => {
+    vi.mocked(prisma.trip.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.tripFollow.findMany).mockResolvedValue(MOCK_FOLLOWS as never);
+    const { default: DashboardPage } = await import("@/app/(app)/dashboard/page");
+    const jsx = await DashboardPage();
+    render(jsx as React.ReactElement);
+    expect(screen.getByText("Saved Trips")).toBeInTheDocument();
+    expect(screen.getByText("Tokyo Adventure")).toBeInTheDocument();
+    expect(screen.getByText(/Shared by Alex/i)).toBeInTheDocument();
+  });
+
+  it("does not render 'Saved Trips' when user has no follows", async () => {
+    vi.mocked(prisma.trip.findMany).mockResolvedValue(MOCK_TRIPS as never);
+    vi.mocked(prisma.tripFollow.findMany).mockResolvedValue([]);
+    const { default: DashboardPage } = await import("@/app/(app)/dashboard/page");
+    const jsx = await DashboardPage();
+    render(jsx as React.ReactElement);
+    expect(screen.queryByText("Saved Trips")).not.toBeInTheDocument();
+  });
+
+  it("shows empty-state CTA only when both owned and followed trips are empty", async () => {
+    vi.mocked(prisma.trip.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.tripFollow.findMany).mockResolvedValue([]);
+    const { default: DashboardPage } = await import("@/app/(app)/dashboard/page");
+    const jsx = await DashboardPage();
+    render(jsx as React.ReactElement);
+    expect(screen.getByText(/no trips yet/i)).toBeInTheDocument();
+  });
+
+  it("does not show empty-state CTA when user has no owned trips but has follows", async () => {
+    vi.mocked(prisma.trip.findMany).mockResolvedValue([]);
+    vi.mocked(prisma.tripFollow.findMany).mockResolvedValue(MOCK_FOLLOWS as never);
+    const { default: DashboardPage } = await import("@/app/(app)/dashboard/page");
+    const jsx = await DashboardPage();
+    render(jsx as React.ReactElement);
+    expect(screen.queryByText(/no trips yet/i)).not.toBeInTheDocument();
   });
 });

--- a/tests/unit/components/SharePage.test.tsx
+++ b/tests/unit/components/SharePage.test.tsx
@@ -1,0 +1,58 @@
+import { describe, it, expect, vi, beforeEach } from "vitest";
+import { render, screen } from "@testing-library/react";
+
+vi.mock("next-auth", () => ({ getServerSession: vi.fn() }));
+vi.mock("@/lib/auth", () => ({ authOptions: {} }));
+vi.mock("next/navigation", () => ({
+  redirect: vi.fn(),
+  useRouter: vi.fn(() => ({ push: vi.fn() })),
+  usePathname: vi.fn(() => "/"),
+  useSearchParams: vi.fn(() => new URLSearchParams()),
+}));
+
+import { getServerSession } from "next-auth";
+import { redirect } from "next/navigation";
+import { prisma } from "@/lib/prisma";
+
+const SESSION_FOLLOWER = { user: { id: "follower-1", name: "Jane" } };
+const SESSION_OWNER = { user: { id: "owner-1", name: "Matt" } };
+
+const TRIP_DB = {
+  id: "trip-1",
+  user_id: "owner-1",
+  name: "Italy Trip",
+  destination: "Rome, Italy",
+  start_date: new Date("2026-05-01T12:00:00Z"),
+  end_date: new Date("2026-05-07T12:00:00Z"),
+  user: { name: "Matt" },
+};
+
+describe("SharePage", () => {
+  it("redirects unauthenticated users to /login with callbackUrl", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(null);
+    const { default: SharePage } = await import("@/app/share/[token]/page");
+    await SharePage({ params: { token: "abc" } });
+    expect(redirect).toHaveBeenCalledWith("/login?callbackUrl=/share/abc");
+  });
+
+  it("shows error message when token not found", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(SESSION_FOLLOWER as never);
+    vi.mocked(prisma.trip.findFirst).mockResolvedValue(null);
+    const { default: SharePage } = await import("@/app/share/[token]/page");
+    const jsx = await SharePage({ params: { token: "bad" } });
+    render(jsx as React.ReactElement);
+    expect(screen.getByText(/no longer active/i)).toBeInTheDocument();
+  });
+
+  it("renders trip preview with owner attribution for a stranger", async () => {
+    vi.mocked(getServerSession).mockResolvedValue(SESSION_FOLLOWER as never);
+    vi.mocked(prisma.trip.findFirst).mockResolvedValue(TRIP_DB as never);
+    vi.mocked(prisma.tripFollow.findUnique).mockResolvedValue(null);
+    const { default: SharePage } = await import("@/app/share/[token]/page");
+    const jsx = await SharePage({ params: { token: "abc123" } });
+    render(jsx as React.ReactElement);
+    expect(screen.getByText("Italy Trip")).toBeInTheDocument();
+    expect(screen.getByText(/Rome, Italy/i)).toBeInTheDocument();
+    expect(screen.getByText(/Shared by Matt/i)).toBeInTheDocument();
+  });
+});

--- a/tests/unit/components/TripCard.test.tsx
+++ b/tests/unit/components/TripCard.test.tsx
@@ -61,4 +61,33 @@ describe("TripCard", () => {
     expect(link).toHaveTextContent("Summer in Italy");
     expect(link).toHaveTextContent("Rome, Italy");
   });
+
+  // ── sharedBy attribution ────────────────────────────────────────────────────
+
+  it("renders 'Shared by' attribution when sharedBy prop is set", () => {
+    render(
+      <TripCard
+        id="trip-1"
+        name="Italy Trip"
+        destination="Rome, Italy"
+        start_date={null}
+        end_date={null}
+        sharedBy="Matt"
+      />
+    );
+    expect(screen.getByText(/Shared by Matt/i)).toBeInTheDocument();
+  });
+
+  it("does not render attribution when sharedBy is not set", () => {
+    render(
+      <TripCard
+        id="trip-1"
+        name="Italy Trip"
+        destination="Rome, Italy"
+        start_date={null}
+        end_date={null}
+      />
+    );
+    expect(screen.queryByText(/Shared by/i)).not.toBeInTheDocument();
+  });
 });


### PR DESCRIPTION
## Summary

- Trip owners can generate a share link (Share button in the trip header) that copies a URL to the clipboard. Revoking the link (via a second click) sets `share_token = null` without evicting existing followers.
- Recipients open the link, see a preview card with the trip name, destination, date range, and owner attribution, and click "Save to my trips" to create a `TripFollow` record — no document upload needed.
- Saved trips appear on the follower's dashboard under a new "Saved Trips" section (with "Shared by [owner]" attribution). Followers access the full companion UI (Itinerary, Map, Chat, Checklist) as a live read-only view — they always see the owner's current data.
- Followers see an Unsave button instead of Share; edit controls (location editing, checklist mutations) are hidden. Revoking the share link stops new saves but does not evict existing followers.

## Changes

**Schema:** `share_token String? @unique` on `Trip`; new `TripFollow` join table with composite unique index and cascade deletes.

**New API routes:**
- `POST /DELETE /api/trips/[id]/share` — generate/revoke token (owner only, idempotent)
- `GET /api/share/[token]` — public trip preview by token
- `POST /api/share/[token]/follow` — upsert TripFollow (idempotent)
- `DELETE /api/trips/[id]/follow` — unsave (204 no-op if already unfollowed)

**Relaxed routes:** `GET /api/trips/[id]` and `POST /api/trips/[id]/chat` now allow owner-or-follower access.

**New pages:** `app/share/[token]/page.tsx` (server component outside route groups) + `app/share/layout.tsx`.

**Component changes:** `TripCompanionClient` (`readOnly`/`ownerName` props, Share/Unsave buttons), `ChecklistTab` (`readOnly` prop), `TripCard` (`sharedBy` prop), dashboard with parallel followed-trips query.

**Tests:** 37 new tests (277 total, up from 240).

## Test plan

- [ ] Run `npm test` — all 277 tests green
- [ ] Run `npx prisma db push` on target environment to apply schema
- [ ] Owner: click Share button → share URL copied to clipboard
- [ ] Recipient: open share URL → preview card shown → "Save to my trips" → redirected to `/trips/[id]` in read-only mode
- [ ] Follower dashboard: "Saved Trips" section appears with "Shared by [name]"
- [ ] Follower trip page: no Edit location links, no checklist mutation controls, no Edit modal
- [ ] Follower: click Unsave → redirected to dashboard, trip removed from Saved Trips
- [ ] Owner: revoke share link → existing followers retain access, new share links blocked

Closes #8

🤖 Generated with [Claude Code](https://claude.com/claude-code)